### PR TITLE
Use ViewmodelScope instead of creating coroutine scope

### DIFF
--- a/DevBytes-starter/app/build.gradle
+++ b/DevBytes-starter/app/build.gradle
@@ -28,8 +28,8 @@ android {
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -54,7 +54,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
 
     // Android KTX
-    implementation 'androidx.core:core-ktx:1.0.2'
+    implementation 'androidx.core:core-ktx:1.3.1'
 
     // constraint layout
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
@@ -87,6 +87,7 @@ dependencies {
     // ViewModel and LiveData
     def lifecycle_version = "2.2.0"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
     // logging
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/DevBytes-starter/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
+++ b/DevBytes-starter/app/src/main/java/com/example/android/devbyteviewer/viewmodels/DevByteViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.example.android.devbyteviewer.domain.DevByteVideo
 import com.example.android.devbyteviewer.network.DevByteNetwork
 import com.example.android.devbyteviewer.network.asDomainModel
@@ -39,21 +40,6 @@ import java.io.IOException
  * or fragment lifecycle events.
  */
 class DevByteViewModel(application: Application) : AndroidViewModel(application) {
-
-    /**
-     * This is the job for all coroutines started by this ViewModel.
-     *
-     * Cancelling this job will cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = SupervisorJob()
-
-    /**
-     * This is the main scope for all coroutines launched by MainViewModel.
-     *
-     * Since we pass viewModelJob, you can cancel all coroutines launched by uiScope by calling
-     * viewModelJob.cancel()
-     */
-    private val viewModelScope = CoroutineScope(viewModelJob + Dispatchers.Main)
 
     /**
      * A playlist of videos that can be shown on the screen. This is private to avoid exposing a
@@ -127,15 +113,6 @@ class DevByteViewModel(application: Application) : AndroidViewModel(application)
      */
     fun onNetworkErrorShown() {
         _isNetworkErrorShown.value = true
-    }
-
-
-    /**
-     * Cancel all coroutines when the ViewModel is cleared
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 
     /**

--- a/RecyclerViewClickHandler-Starter/app/build.gradle
+++ b/RecyclerViewClickHandler-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
@@ -31,7 +31,7 @@ import androidx.room.Update
 interface SleepDatabaseDao {
 
     @Insert
-    fun insert(night: SleepNight)
+    suspend fun insert(night: SleepNight)
 
     /**
      * When updating a row with a value already set in a column,
@@ -40,7 +40,7 @@ interface SleepDatabaseDao {
      * @param night new value to write
      */
     @Update
-    fun update(night: SleepNight)
+    suspend fun update(night: SleepNight)
 
     /**
      * Selects and returns the row that matches the supplied start time, which is our key.
@@ -48,7 +48,7 @@ interface SleepDatabaseDao {
      * @param key startTimeMilli to match
      */
     @Query("SELECT * from daily_sleep_quality_table WHERE nightId = :key")
-    fun get(key: Long): SleepNight
+    suspend fun get(key: Long): SleepNight
 
     /**
      * Deletes all values from the table.
@@ -56,7 +56,7 @@ interface SleepDatabaseDao {
      * This does not delete the table, only its contents.
      */
     @Query("DELETE FROM daily_sleep_quality_table")
-    fun clear()
+    suspend fun clear()
 
     /**
      * Selects and returns all rows in the table,
@@ -70,7 +70,7 @@ interface SleepDatabaseDao {
      * Selects and returns the latest night.
      */
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC LIMIT 1")
-    fun getTonight(): SleepNight?
+    suspend fun getTonight(): SleepNight?
 
     /**
      * Selects and returns the night with given nightId.

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepdetail/SleepDetailFragment.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepdetail/SleepDetailFragment.kt
@@ -67,7 +67,7 @@ class SleepDetailFragment : Fragment() {
         binding.setLifecycleOwner(this)
 
         // Add an Observer to the state variable for Navigating when a Quality icon is tapped.
-        sleepDetailViewModel.navigateToSleepTracker.observe(this, Observer {
+        sleepDetailViewModel.navigateToSleepTracker.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 this.findNavController().navigate(
                         SleepDetailFragmentDirections.actionSleepDetailFragmentToSleepTrackerFragment())

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepdetail/SleepDetailViewModel.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepdetail/SleepDetailViewModel.kt
@@ -42,13 +42,6 @@ class SleepDetailViewModel(
      */
     val database = dataSource
 
-    /** Coroutine setup variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = Job()
-
     private val night: LiveData<SleepNight>
 
     fun getNight() = night
@@ -71,16 +64,6 @@ class SleepDetailViewModel(
      */
     val navigateToSleepTracker: LiveData<Boolean?>
         get() = _navigateToSleepTracker
-
-    /**
-     * Cancels all coroutines when the ViewModel is cleared, to cleanup any pending work.
-     *
-     * onCleared() gets called when the ViewModel is destroyed.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
-    }
 
 
     /**

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
@@ -70,7 +70,7 @@ class SleepQualityFragment : Fragment() {
         binding.sleepQualityViewModel = sleepQualityViewModel
 
         // Add an Observer to the state variable for Navigating when a Quality icon is tapped.
-        sleepQualityViewModel.navigateToSleepTracker.observe(this, Observer {
+        sleepQualityViewModel.navigateToSleepTracker.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 this.findNavController().navigate(
                         SleepQualityFragmentDirections.actionSleepQualityFragmentToSleepTrackerFragment())

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
@@ -19,12 +19,9 @@ package com.example.android.trackmysleepquality.sleepquality
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepQualityFragment.
@@ -39,25 +36,6 @@ class SleepQualityViewModel(
      * Hold a reference to SleepDatabase via its SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine setup variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this scope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     /**
      * Variable that tells the fragment whether it should navigate to [SleepTrackerFragment].
@@ -74,17 +52,6 @@ class SleepQualityViewModel(
         get() = _navigateToSleepTracker
 
     /**
-     * Cancels all coroutines when the ViewModel is cleared, to cleanup any pending work.
-     *
-     * onCleared() gets called when the ViewModel is destroyed.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
-    }
-
-
-    /**
      * Call this immediately after navigating to [SleepTrackerFragment]
      */
     fun doneNavigating() {
@@ -97,14 +64,10 @@ class SleepQualityViewModel(
      * Then navigates back to the SleepTrackerFragment.
      */
     fun onSetSleepQuality(quality: Int) {
-        uiScope.launch {
-            // IO is a thread pool for running operations that access the disk, such as
-            // our Room database.
-            withContext(Dispatchers.IO) {
-                val tonight = database.get(sleepNightKey)
-                tonight.sleepQuality = quality
-                database.update(tonight)
-            }
+        viewModelScope.launch {
+            val tonight = database.get(sleepNightKey)
+            tonight.sleepQuality = quality
+            database.update(tonight)
 
             // Setting this state variable to true will alert the observer and trigger navigation.
             _navigateToSleepTracker.value = true

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -85,10 +85,10 @@ class SleepTrackerFragment : Fragment() {
 
         // Add an Observer on the state variable for showing a Snackbar message
         // when the CLEAR button is pressed.
-        sleepTrackerViewModel.showSnackBarEvent.observe(this, Observer {
+        sleepTrackerViewModel.showSnackBarEvent.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 Snackbar.make(
-                        activity!!.findViewById(android.R.id.content),
+                        requireActivity().findViewById(android.R.id.content),
                         getString(R.string.cleared_message),
                         Snackbar.LENGTH_SHORT // How long to display the message.
                 ).show()
@@ -99,7 +99,7 @@ class SleepTrackerFragment : Fragment() {
         })
 
         // Add an Observer on the state variable for Navigating when STOP button is pressed.
-        sleepTrackerViewModel.navigateToSleepQuality.observe(this, Observer { night ->
+        sleepTrackerViewModel.navigateToSleepQuality.observe(viewLifecycleOwner, Observer { night ->
             night?.let {
                 // We need to get the navController from this, because button is not ready, and it
                 // just has to be a view. For some reason, this only matters if we hit stop again

--- a/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/RecyclerViewClickHandler-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -21,14 +21,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 import com.example.android.trackmysleepquality.database.SleepNight
 import com.example.android.trackmysleepquality.formatNights
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepTrackerFragment.
@@ -41,25 +38,6 @@ class SleepTrackerViewModel(
      * Hold a reference to SleepDatabase via SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private var viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this uiScope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     private var tonight = MutableLiveData<SleepNight?>()
 
@@ -92,7 +70,6 @@ class SleepTrackerViewModel(
     val clearButtonVisible = Transformations.map(nights) {
         it?.isNotEmpty()
     }
-
 
     /**
      * Request a toast by setting this value to true.
@@ -145,7 +122,7 @@ class SleepTrackerViewModel(
     }
 
     private fun initializeTonight() {
-        uiScope.launch {
+        viewModelScope.launch {
             tonight.value = getTonightFromDatabase()
         }
     }
@@ -158,38 +135,30 @@ class SleepTrackerViewModel(
      *  recording.
      */
     private suspend fun getTonightFromDatabase(): SleepNight? {
-        return withContext(Dispatchers.IO) {
-            var night = database.getTonight()
-            if (night?.endTimeMilli != night?.startTimeMilli) {
-                night = null
-            }
-            night
+        var night = database.getTonight()
+        if (night?.endTimeMilli != night?.startTimeMilli) {
+            night = null
         }
+        return night
     }
 
     private suspend fun insert(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.insert(night)
-        }
+        database.insert(night)
     }
 
     private suspend fun update(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.update(night)
-        }
+        database.update(night)
     }
 
     private suspend fun clear() {
-        withContext(Dispatchers.IO) {
-            database.clear()
-        }
+        database.clear()
     }
 
     /**
      * Executes when the START button is clicked.
      */
     fun onStart() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Create a new night, which captures the current time,
             // and insert it into the database.
             val newNight = SleepNight()
@@ -204,7 +173,7 @@ class SleepTrackerViewModel(
      * Executes when the STOP button is clicked.
      */
     fun onStop() {
-        uiScope.launch {
+        viewModelScope.launch {
             // In Kotlin, the return@label syntax is used for specifying which function among
             // several nested ones this statement returns from.
             // In this case, we are specifying to return from launch().
@@ -224,7 +193,7 @@ class SleepTrackerViewModel(
      * Executes when the CLEAR button is clicked.
      */
     fun onClear() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Clear the database table.
             clear()
 
@@ -234,16 +203,5 @@ class SleepTrackerViewModel(
             // Show a snackbar message, because it's friendly.
             _showSnackbarEvent.value = true
         }
-    }
-
-    /**
-     * Called when the ViewModel is dismantled.
-     * At this point, we want to cancel all coroutines;
-     * otherwise we end up with processes that have nowhere to return to
-     * using memory and resources.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 }

--- a/RecyclerViewClickHandler-Starter/build.gradle
+++ b/RecyclerViewClickHandler-Starter/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.72'
         archLifecycleVersion = '1.1.1'
-        room_version = '2.2.0'
+        room_version = '2.2.5'
         coroutine_version = '1.3.7'
         gradleVersion = '4.0.1'
         navigationVersion = '1.0.0-alpha07'

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/build.gradle
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.0.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
@@ -31,7 +31,7 @@ import androidx.room.Update
 interface SleepDatabaseDao {
 
     @Insert
-    fun insert(night: SleepNight)
+    suspend fun insert(night: SleepNight)
 
     /**
      * When updating a row with a value already set in a column,
@@ -40,7 +40,7 @@ interface SleepDatabaseDao {
      * @param night new value to write
      */
     @Update
-    fun update(night: SleepNight)
+    suspend fun update(night: SleepNight)
 
     /**
      * Selects and returns the row that matches the supplied start time, which is our key.
@@ -48,7 +48,7 @@ interface SleepDatabaseDao {
      * @param key startTimeMilli to match
      */
     @Query("SELECT * from daily_sleep_quality_table WHERE nightId = :key")
-    fun get(key: Long): SleepNight
+    suspend fun get(key: Long): SleepNight
 
     /**
      * Deletes all values from the table.
@@ -56,7 +56,7 @@ interface SleepDatabaseDao {
      * This does not delete the table, only its contents.
      */
     @Query("DELETE FROM daily_sleep_quality_table")
-    fun clear()
+    suspend fun clear()
 
     /**
      * Selects and returns all rows in the table,
@@ -70,5 +70,5 @@ interface SleepDatabaseDao {
      * Selects and returns the latest night.
      */
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC LIMIT 1")
-    fun getTonight(): SleepNight?
+    suspend fun getTonight(): SleepNight?
 }

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
@@ -70,7 +70,7 @@ class SleepQualityFragment : Fragment() {
         binding.sleepQualityViewModel = sleepQualityViewModel
 
         // Add an Observer to the state variable for Navigating when a Quality icon is tapped.
-        sleepQualityViewModel.navigateToSleepTracker.observe(this, Observer {
+        sleepQualityViewModel.navigateToSleepTracker.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 this.findNavController().navigate(
                         SleepQualityFragmentDirections.actionSleepQualityFragmentToSleepTrackerFragment())

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
@@ -19,12 +19,9 @@ package com.example.android.trackmysleepquality.sleepquality
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepQualityFragment.
@@ -39,25 +36,6 @@ class SleepQualityViewModel(
      * Hold a reference to SleepDatabase via its SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine setup variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this scope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     /**
      * Variable that tells the fragment whether it should navigate to [SleepTrackerFragment].
@@ -74,17 +52,6 @@ class SleepQualityViewModel(
         get() = _navigateToSleepTracker
 
     /**
-     * Cancels all coroutines when the ViewModel is cleared, to cleanup any pending work.
-     *
-     * onCleared() gets called when the ViewModel is destroyed.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
-    }
-
-
-    /**
      * Call this immediately after navigating to [SleepTrackerFragment]
      */
     fun doneNavigating() {
@@ -97,14 +64,10 @@ class SleepQualityViewModel(
      * Then navigates back to the SleepTrackerFragment.
      */
     fun onSetSleepQuality(quality: Int) {
-        uiScope.launch {
-            // IO is a thread pool for running operations that access the disk, such as
-            // our Room database.
-            withContext(Dispatchers.IO) {
-                val tonight = database.get(sleepNightKey)
-                tonight.sleepQuality = quality
-                database.update(tonight)
-            }
+        viewModelScope.launch {
+            val tonight = database.get(sleepNightKey)
+            tonight.sleepQuality = quality
+            database.update(tonight)
 
             // Setting this state variable to true will alert the observer and trigger navigation.
             _navigateToSleepTracker.value = true

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -84,10 +84,10 @@ class SleepTrackerFragment : Fragment() {
 
         // Add an Observer on the state variable for showing a Snackbar message
         // when the CLEAR button is pressed.
-        sleepTrackerViewModel.showSnackBarEvent.observe(this, Observer {
+        sleepTrackerViewModel.showSnackBarEvent.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 Snackbar.make(
-                        activity!!.findViewById(android.R.id.content),
+                        requireActivity().findViewById(android.R.id.content),
                         getString(R.string.cleared_message),
                         Snackbar.LENGTH_SHORT // How long to display the message.
                 ).show()
@@ -98,7 +98,7 @@ class SleepTrackerFragment : Fragment() {
         })
 
         // Add an Observer on the state variable for Navigating when STOP button is pressed.
-        sleepTrackerViewModel.navigateToSleepQuality.observe(this, Observer { night ->
+        sleepTrackerViewModel.navigateToSleepQuality.observe(viewLifecycleOwner, Observer { night ->
             night?.let {
                 // We need to get the navController from this, because button is not ready, and it
                 // just has to be a view. For some reason, this only matters if we hit stop again

--- a/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/RecyclerViewDiffUtilDataBinding-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -21,14 +21,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 import com.example.android.trackmysleepquality.database.SleepNight
 import com.example.android.trackmysleepquality.formatNights
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepTrackerFragment.
@@ -41,25 +38,6 @@ class SleepTrackerViewModel(
      * Hold a reference to SleepDatabase via SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private var viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this uiScope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     private var tonight = MutableLiveData<SleepNight?>()
 
@@ -92,7 +70,6 @@ class SleepTrackerViewModel(
     val clearButtonVisible = Transformations.map(nights) {
         it?.isNotEmpty()
     }
-
 
     /**
      * Request a toast by setting this value to true.
@@ -145,7 +122,7 @@ class SleepTrackerViewModel(
     }
 
     private fun initializeTonight() {
-        uiScope.launch {
+        viewModelScope.launch {
             tonight.value = getTonightFromDatabase()
         }
     }
@@ -158,38 +135,30 @@ class SleepTrackerViewModel(
      *  recording.
      */
     private suspend fun getTonightFromDatabase(): SleepNight? {
-        return withContext(Dispatchers.IO) {
-            var night = database.getTonight()
-            if (night?.endTimeMilli != night?.startTimeMilli) {
-                night = null
-            }
-            night
+        var night = database.getTonight()
+        if (night?.endTimeMilli != night?.startTimeMilli) {
+            night = null
         }
+        return night
     }
 
     private suspend fun insert(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.insert(night)
-        }
+        database.insert(night)
     }
 
     private suspend fun update(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.update(night)
-        }
+        database.update(night)
     }
 
     private suspend fun clear() {
-        withContext(Dispatchers.IO) {
-            database.clear()
-        }
+        database.clear()
     }
 
     /**
      * Executes when the START button is clicked.
      */
     fun onStart() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Create a new night, which captures the current time,
             // and insert it into the database.
             val newNight = SleepNight()
@@ -204,7 +173,7 @@ class SleepTrackerViewModel(
      * Executes when the STOP button is clicked.
      */
     fun onStop() {
-        uiScope.launch {
+        viewModelScope.launch {
             // In Kotlin, the return@label syntax is used for specifying which function among
             // several nested ones this statement returns from.
             // In this case, we are specifying to return from launch().
@@ -224,7 +193,7 @@ class SleepTrackerViewModel(
      * Executes when the CLEAR button is clicked.
      */
     fun onClear() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Clear the database table.
             clear()
 
@@ -234,16 +203,5 @@ class SleepTrackerViewModel(
             // Show a snackbar message, because it's friendly.
             _showSnackbarEvent.value = true
         }
-    }
-
-    /**
-     * Called when the ViewModel is dismantled.
-     * At this point, we want to cancel all coroutines;
-     * otherwise we end up with processes that have nowhere to return to
-     * using memory and resources.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 }

--- a/RecyclerViewDiffUtilDataBinding-Starter/build.gradle
+++ b/RecyclerViewDiffUtilDataBinding-Starter/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.72'
         archLifecycleVersion = '1.1.1'
-        room_version = '2.2.0'
+        room_version = '2.2.5'
         coroutine_version = '1.3.7'
         gradleVersion = '4.0.1'
         navigationVersion = '1.0.0-alpha07'

--- a/RecyclerViewFundamentals-Starter/app/build.gradle
+++ b/RecyclerViewFundamentals-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
+++ b/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
@@ -31,7 +31,7 @@ import androidx.room.Update
 interface SleepDatabaseDao {
 
     @Insert
-    fun insert(night: SleepNight)
+    suspend fun insert(night: SleepNight)
 
     /**
      * When updating a row with a value already set in a column,
@@ -40,7 +40,7 @@ interface SleepDatabaseDao {
      * @param night new value to write
      */
     @Update
-    fun update(night: SleepNight)
+    suspend fun update(night: SleepNight)
 
     /**
      * Selects and returns the row that matches the supplied start time, which is our key.
@@ -48,7 +48,7 @@ interface SleepDatabaseDao {
      * @param key startTimeMilli to match
      */
     @Query("SELECT * from daily_sleep_quality_table WHERE nightId = :key")
-    fun get(key: Long): SleepNight
+    suspend fun get(key: Long): SleepNight
 
     /**
      * Deletes all values from the table.
@@ -56,7 +56,7 @@ interface SleepDatabaseDao {
      * This does not delete the table, only its contents.
      */
     @Query("DELETE FROM daily_sleep_quality_table")
-    fun clear()
+    suspend fun clear()
 
     /**
      * Selects and returns all rows in the table,
@@ -70,5 +70,5 @@ interface SleepDatabaseDao {
      * Selects and returns the latest night.
      */
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC LIMIT 1")
-    fun getTonight(): SleepNight?
+    suspend fun getTonight(): SleepNight?
 }

--- a/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
+++ b/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
@@ -70,7 +70,7 @@ class SleepQualityFragment : Fragment() {
         binding.sleepQualityViewModel = sleepQualityViewModel
 
         // Add an Observer to the state variable for Navigating when a Quality icon is tapped.
-        sleepQualityViewModel.navigateToSleepTracker.observe(this, Observer {
+        sleepQualityViewModel.navigateToSleepTracker.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 this.findNavController().navigate(
                         SleepQualityFragmentDirections.actionSleepQualityFragmentToSleepTrackerFragment())

--- a/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
+++ b/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
@@ -19,12 +19,9 @@ package com.example.android.trackmysleepquality.sleepquality
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepQualityFragment.
@@ -40,25 +37,6 @@ class SleepQualityViewModel(
      */
     val database = dataSource
 
-    /** Coroutine setup variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this scope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
-
     /**
      * Variable that tells the fragment whether it should navigate to [SleepTrackerFragment].
      *
@@ -72,16 +50,6 @@ class SleepQualityViewModel(
      */
     val navigateToSleepTracker: LiveData<Boolean?>
         get() = _navigateToSleepTracker
-
-    /**
-     * Cancels all coroutines when the ViewModel is cleared, to cleanup any pending work.
-     *
-     * onCleared() gets called when the ViewModel is destroyed.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
-    }
 
 
     /**
@@ -97,14 +65,10 @@ class SleepQualityViewModel(
      * Then navigates back to the SleepTrackerFragment.
      */
     fun onSetSleepQuality(quality: Int) {
-        uiScope.launch {
-            // IO is a thread pool for running operations that access the disk, such as
-            // our Room database.
-            withContext(Dispatchers.IO) {
+        viewModelScope.launch {
                 val tonight = database.get(sleepNightKey)
                 tonight.sleepQuality = quality
                 database.update(tonight)
-            }
 
             // Setting this state variable to true will alert the observer and trigger navigation.
             _navigateToSleepTracker.value = true

--- a/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -75,10 +75,10 @@ class SleepTrackerFragment : Fragment() {
 
         // Add an Observer on the state variable for showing a Snackbar message
         // when the CLEAR button is pressed.
-        sleepTrackerViewModel.showSnackBarEvent.observe(this, Observer {
+        sleepTrackerViewModel.showSnackBarEvent.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 Snackbar.make(
-                        activity!!.findViewById(android.R.id.content),
+                        requireActivity().findViewById(android.R.id.content),
                         getString(R.string.cleared_message),
                         Snackbar.LENGTH_SHORT // How long to display the message.
                 ).show()
@@ -89,7 +89,7 @@ class SleepTrackerFragment : Fragment() {
         })
 
         // Add an Observer on the state variable for Navigating when STOP button is pressed.
-        sleepTrackerViewModel.navigateToSleepQuality.observe(this, Observer { night ->
+        sleepTrackerViewModel.navigateToSleepQuality.observe(viewLifecycleOwner, Observer { night ->
             night?.let {
                 // We need to get the navController from this, because button is not ready, and it
                 // just has to be a view. For some reason, this only matters if we hit stop again

--- a/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/RecyclerViewFundamentals-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -21,14 +21,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 import com.example.android.trackmysleepquality.database.SleepNight
 import com.example.android.trackmysleepquality.formatNights
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepTrackerFragment.
@@ -41,25 +38,6 @@ class SleepTrackerViewModel(
      * Hold a reference to SleepDatabase via SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private var viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this uiScope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     private var tonight = MutableLiveData<SleepNight?>()
 
@@ -92,7 +70,6 @@ class SleepTrackerViewModel(
     val clearButtonVisible = Transformations.map(nights) {
         it?.isNotEmpty()
     }
-
 
     /**
      * Request a toast by setting this value to true.
@@ -145,7 +122,7 @@ class SleepTrackerViewModel(
     }
 
     private fun initializeTonight() {
-        uiScope.launch {
+        viewModelScope.launch {
             tonight.value = getTonightFromDatabase()
         }
     }
@@ -158,38 +135,30 @@ class SleepTrackerViewModel(
      *  recording.
      */
     private suspend fun getTonightFromDatabase(): SleepNight? {
-        return withContext(Dispatchers.IO) {
             var night = database.getTonight()
             if (night?.endTimeMilli != night?.startTimeMilli) {
                 night = null
             }
-            night
-        }
+            return night
     }
 
     private suspend fun insert(night: SleepNight) {
-        withContext(Dispatchers.IO) {
             database.insert(night)
-        }
     }
 
     private suspend fun update(night: SleepNight) {
-        withContext(Dispatchers.IO) {
             database.update(night)
-        }
     }
 
     private suspend fun clear() {
-        withContext(Dispatchers.IO) {
             database.clear()
-        }
     }
 
     /**
      * Executes when the START button is clicked.
      */
     fun onStart() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Create a new night, which captures the current time,
             // and insert it into the database.
             val newNight = SleepNight()
@@ -204,7 +173,7 @@ class SleepTrackerViewModel(
      * Executes when the STOP button is clicked.
      */
     fun onStop() {
-        uiScope.launch {
+        viewModelScope.launch {
             // In Kotlin, the return@label syntax is used for specifying which function among
             // several nested ones this statement returns from.
             // In this case, we are specifying to return from launch().
@@ -224,7 +193,7 @@ class SleepTrackerViewModel(
      * Executes when the CLEAR button is clicked.
      */
     fun onClear() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Clear the database table.
             clear()
 
@@ -234,16 +203,5 @@ class SleepTrackerViewModel(
             // Show a snackbar message, because it's friendly.
             _showSnackbarEvent.value = true
         }
-    }
-
-    /**
-     * Called when the ViewModel is dismantled.
-     * At this point, we want to cancel all coroutines;
-     * otherwise we end up with processes that have nowhere to return to
-     * using memory and resources.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 }

--- a/RecyclerViewFundamentals-Starter/build.gradle
+++ b/RecyclerViewFundamentals-Starter/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.72'
         archLifecycleVersion = '1.1.1'
-        room_version = '2.2.0'
+        room_version = '2.2.5'
         coroutine_version = '1.3.7'
         gradleVersion = '4.0.1'
         navigationVersion = '1.0.0-alpha07'

--- a/RecyclerViewGridLayout-Starter/app/build.gradle
+++ b/RecyclerViewGridLayout-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
+++ b/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
@@ -31,7 +31,7 @@ import androidx.room.Update
 interface SleepDatabaseDao {
 
     @Insert
-    fun insert(night: SleepNight)
+    suspend fun insert(night: SleepNight)
 
     /**
      * When updating a row with a value already set in a column,
@@ -40,7 +40,7 @@ interface SleepDatabaseDao {
      * @param night new value to write
      */
     @Update
-    fun update(night: SleepNight)
+    suspend fun update(night: SleepNight)
 
     /**
      * Selects and returns the row that matches the supplied start time, which is our key.
@@ -48,7 +48,7 @@ interface SleepDatabaseDao {
      * @param key startTimeMilli to match
      */
     @Query("SELECT * from daily_sleep_quality_table WHERE nightId = :key")
-    fun get(key: Long): SleepNight
+    suspend fun get(key: Long): SleepNight
 
     /**
      * Deletes all values from the table.
@@ -56,7 +56,7 @@ interface SleepDatabaseDao {
      * This does not delete the table, only its contents.
      */
     @Query("DELETE FROM daily_sleep_quality_table")
-    fun clear()
+    suspend fun clear()
 
     /**
      * Selects and returns all rows in the table,
@@ -70,5 +70,5 @@ interface SleepDatabaseDao {
      * Selects and returns the latest night.
      */
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC LIMIT 1")
-    fun getTonight(): SleepNight?
+    suspend fun getTonight(): SleepNight?
 }

--- a/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
+++ b/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityFragment.kt
@@ -70,7 +70,7 @@ class SleepQualityFragment : Fragment() {
         binding.sleepQualityViewModel = sleepQualityViewModel
 
         // Add an Observer to the state variable for Navigating when a Quality icon is tapped.
-        sleepQualityViewModel.navigateToSleepTracker.observe(this, Observer {
+        sleepQualityViewModel.navigateToSleepTracker.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 this.findNavController().navigate(
                         SleepQualityFragmentDirections.actionSleepQualityFragmentToSleepTrackerFragment())

--- a/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
+++ b/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleepquality/SleepQualityViewModel.kt
@@ -19,12 +19,9 @@ package com.example.android.trackmysleepquality.sleepquality
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepQualityFragment.
@@ -39,25 +36,6 @@ class SleepQualityViewModel(
      * Hold a reference to SleepDatabase via its SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine setup variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private val viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this scope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     /**
      * Variable that tells the fragment whether it should navigate to [SleepTrackerFragment].
@@ -74,17 +52,6 @@ class SleepQualityViewModel(
         get() = _navigateToSleepTracker
 
     /**
-     * Cancels all coroutines when the ViewModel is cleared, to cleanup any pending work.
-     *
-     * onCleared() gets called when the ViewModel is destroyed.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
-    }
-
-
-    /**
      * Call this immediately after navigating to [SleepTrackerFragment]
      */
     fun doneNavigating() {
@@ -97,14 +64,10 @@ class SleepQualityViewModel(
      * Then navigates back to the SleepTrackerFragment.
      */
     fun onSetSleepQuality(quality: Int) {
-        uiScope.launch {
-            // IO is a thread pool for running operations that access the disk, such as
-            // our Room database.
-            withContext(Dispatchers.IO) {
-                val tonight = database.get(sleepNightKey)
-                tonight.sleepQuality = quality
-                database.update(tonight)
-            }
+        viewModelScope.launch {
+            val tonight = database.get(sleepNightKey)
+            tonight.sleepQuality = quality
+            database.update(tonight)
 
             // Setting this state variable to true will alert the observer and trigger navigation.
             _navigateToSleepTracker.value = true

--- a/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
+++ b/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerFragment.kt
@@ -84,10 +84,10 @@ class SleepTrackerFragment : Fragment() {
 
         // Add an Observer on the state variable for showing a Snackbar message
         // when the CLEAR button is pressed.
-        sleepTrackerViewModel.showSnackBarEvent.observe(this, Observer {
+        sleepTrackerViewModel.showSnackBarEvent.observe(viewLifecycleOwner, Observer {
             if (it == true) { // Observed state is true.
                 Snackbar.make(
-                        activity!!.findViewById(android.R.id.content),
+                        requireActivity().findViewById(android.R.id.content),
                         getString(R.string.cleared_message),
                         Snackbar.LENGTH_SHORT // How long to display the message.
                 ).show()
@@ -98,7 +98,7 @@ class SleepTrackerFragment : Fragment() {
         })
 
         // Add an Observer on the state variable for Navigating when STOP button is pressed.
-        sleepTrackerViewModel.navigateToSleepQuality.observe(this, Observer { night ->
+        sleepTrackerViewModel.navigateToSleepQuality.observe(viewLifecycleOwner, Observer { night ->
             night?.let {
                 // We need to get the navController from this, because button is not ready, and it
                 // just has to be a view. For some reason, this only matters if we hit stop again

--- a/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/RecyclerViewGridLayout-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -21,14 +21,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 import com.example.android.trackmysleepquality.database.SleepNight
 import com.example.android.trackmysleepquality.formatNights
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel for SleepTrackerFragment.
@@ -41,25 +38,6 @@ class SleepTrackerViewModel(
      * Hold a reference to SleepDatabase via SleepDatabaseDao.
      */
     val database = dataSource
-
-    /** Coroutine variables */
-
-    /**
-     * viewModelJob allows us to cancel all coroutines started by this ViewModel.
-     */
-    private var viewModelJob = Job()
-
-    /**
-     * A [CoroutineScope] keeps track of all coroutines started by this ViewModel.
-     *
-     * Because we pass it [viewModelJob], any coroutine started in this uiScope can be cancelled
-     * by calling `viewModelJob.cancel()`
-     *
-     * By default, all coroutines started in uiScope will launch in [Dispatchers.Main] which is
-     * the main thread on Android. This is a sensible default because most coroutines started by
-     * a [ViewModel] update the UI after performing some processing.
-     */
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
 
     private var tonight = MutableLiveData<SleepNight?>()
 
@@ -92,7 +70,6 @@ class SleepTrackerViewModel(
     val clearButtonVisible = Transformations.map(nights) {
         it?.isNotEmpty()
     }
-
 
     /**
      * Request a toast by setting this value to true.
@@ -145,7 +122,7 @@ class SleepTrackerViewModel(
     }
 
     private fun initializeTonight() {
-        uiScope.launch {
+        viewModelScope.launch {
             tonight.value = getTonightFromDatabase()
         }
     }
@@ -158,38 +135,30 @@ class SleepTrackerViewModel(
      *  recording.
      */
     private suspend fun getTonightFromDatabase(): SleepNight? {
-        return withContext(Dispatchers.IO) {
-            var night = database.getTonight()
-            if (night?.endTimeMilli != night?.startTimeMilli) {
-                night = null
-            }
-            night
+        var night = database.getTonight()
+        if (night?.endTimeMilli != night?.startTimeMilli) {
+            night = null
         }
+        return night
     }
 
     private suspend fun insert(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.insert(night)
-        }
+        database.insert(night)
     }
 
     private suspend fun update(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.update(night)
-        }
+        database.update(night)
     }
 
     private suspend fun clear() {
-        withContext(Dispatchers.IO) {
-            database.clear()
-        }
+        database.clear()
     }
 
     /**
      * Executes when the START button is clicked.
      */
     fun onStart() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Create a new night, which captures the current time,
             // and insert it into the database.
             val newNight = SleepNight()
@@ -204,7 +173,7 @@ class SleepTrackerViewModel(
      * Executes when the STOP button is clicked.
      */
     fun onStop() {
-        uiScope.launch {
+        viewModelScope.launch {
             // In Kotlin, the return@label syntax is used for specifying which function among
             // several nested ones this statement returns from.
             // In this case, we are specifying to return from launch().
@@ -224,7 +193,7 @@ class SleepTrackerViewModel(
      * Executes when the CLEAR button is clicked.
      */
     fun onClear() {
-        uiScope.launch {
+        viewModelScope.launch {
             // Clear the database table.
             clear()
 
@@ -234,16 +203,5 @@ class SleepTrackerViewModel(
             // Show a snackbar message, because it's friendly.
             _showSnackbarEvent.value = true
         }
-    }
-
-    /**
-     * Called when the ViewModel is dismantled.
-     * At this point, we want to cancel all coroutines;
-     * otherwise we end up with processes that have nowhere to return to
-     * using memory and resources.
-     */
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
     }
 }

--- a/RecyclerViewGridLayout-Starter/build.gradle
+++ b/RecyclerViewGridLayout-Starter/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     ext {
         kotlin_version = '1.3.72'
         archLifecycleVersion = '1.1.1'
-        room_version = '2.2.0'
+        room_version = '2.2.5'
         coroutine_version = '1.0.0'
         gradleVersion = '4.0.1'
         navigationVersion = '1.0.0-alpha07'

--- a/TrackMySleepQuality-Starter/app/build.gradle
+++ b/TrackMySleepQuality-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
@@ -71,5 +75,10 @@ dependencies {
     // Navigation
     implementation "android.arch.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "android.arch.navigation:navigation-ui-ktx:$navigationVersion"
+
+    // Testing
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }
 

--- a/TrackMySleepQualityCoroutines-Starter/app/build.gradle
+++ b/TrackMySleepQualityCoroutines-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/TrackMySleepQualityStates-Starter/app/build.gradle
+++ b/TrackMySleepQualityStates-Starter/app/build.gradle
@@ -63,6 +63,10 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     kapt "androidx.room:room-compiler:$room_version"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
+
+    // Kotlin Extensions and Coroutines support for Room
+    implementation "androidx.room:room-ktx:$room_version"
 
     // Coroutines
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"
@@ -71,5 +75,10 @@ dependencies {
     // Navigation
     implementation "android.arch.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "android.arch.navigation:navigation-ui-ktx:$navigationVersion"
+
+    // Testing
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }
 

--- a/TrackMySleepQualityStates-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
+++ b/TrackMySleepQualityStates-Starter/app/src/main/java/com/example/android/trackmysleepquality/database/SleepDatabaseDao.kt
@@ -26,19 +26,19 @@ import androidx.room.Update
 interface SleepDatabaseDao {
 
     @Insert
-    fun insert(night: SleepNight)
+    suspend fun insert(night: SleepNight)
 
     @Update
-    fun update(night: SleepNight)
+    suspend fun update(night: SleepNight)
 
     @Query("SELECT * from daily_sleep_quality_table WHERE nightId = :key")
-    fun get(key: Long): SleepNight?
+    suspend fun get(key: Long): SleepNight?
 
     @Query("DELETE FROM daily_sleep_quality_table")
-    fun clear()
+    suspend fun clear()
 
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC LIMIT 1")
-    fun getTonight(): SleepNight?
+    suspend fun getTonight(): SleepNight?
 
     @Query("SELECT * FROM daily_sleep_quality_table ORDER BY nightId DESC")
     fun getAllNights(): LiveData<List<SleepNight>>

--- a/TrackMySleepQualityStates-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
+++ b/TrackMySleepQualityStates-Starter/app/src/main/java/com/example/android/trackmysleepquality/sleeptracker/SleepTrackerViewModel.kt
@@ -20,6 +20,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations
+import androidx.lifecycle.viewModelScope
 import com.example.android.trackmysleepquality.database.SleepDatabaseDao
 import com.example.android.trackmysleepquality.database.SleepNight
 import com.example.android.trackmysleepquality.formatNights
@@ -36,11 +37,6 @@ class SleepTrackerViewModel(
         val database: SleepDatabaseDao,
         application: Application) : AndroidViewModel(application) {
 
-    private var viewModelJob = Job()
-
-
-    private val uiScope = CoroutineScope(Dispatchers.Main + viewModelJob)
-
     private val nights = database.getAllNights()
 
     val nightsString = Transformations.map(nights) { nights ->
@@ -54,25 +50,22 @@ class SleepTrackerViewModel(
     }
 
     private fun initializeTonight() {
-        uiScope.launch {
+        viewModelScope.launch {
             tonight.value = getTonightFromDatabase()
         }
     }
 
     private suspend fun getTonightFromDatabase(): SleepNight? {
-
-        return withContext(Dispatchers.IO) {
-
-            var night = database.getTonight()
-            if (night?.endTimeMilli != night?.startTimeMilli) {
-                night = null
-            }
-            night
+        var night = database.getTonight()
+        if (night?.endTimeMilli != night?.startTimeMilli) {
+            night = null
         }
+        return night
     }
 
+
     fun onStartTracking() {
-        uiScope.launch {
+        viewModelScope.launch {
             val newNight = SleepNight()
             insert(newNight)
             tonight.value = getTonightFromDatabase()
@@ -80,13 +73,12 @@ class SleepTrackerViewModel(
     }
 
     private suspend fun insert(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.insert(night)
-        }
+        database.insert(night)
+
     }
 
     fun onStopTracking() {
-        uiScope.launch {
+        viewModelScope.launch {
             val oldNight = tonight.value ?: return@launch
             oldNight.endTimeMilli = System.currentTimeMillis()
             update(oldNight)
@@ -94,27 +86,18 @@ class SleepTrackerViewModel(
     }
 
     private suspend fun update(night: SleepNight) {
-        withContext(Dispatchers.IO) {
-            database.update(night)
-        }
+        database.update(night)
     }
 
     fun onClear() {
-        uiScope.launch {
+        viewModelScope.launch {
             clear()
             tonight.value = null
         }
     }
 
     suspend fun clear() {
-        withContext(Dispatchers.IO) {
-            database.clear()
-        }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        viewModelJob.cancel()
+        database.clear()
     }
 }
 


### PR DESCRIPTION
* Use viewModelScope to call the database operations.
* Remove Dispatcher.IO context and coroutine scope for @Dao methods.

Room library automatically moves database calls onto a background thread, so you don't explicitly need to move them to a background thread. A suspend @Dao method and a `@Query` method returning LiveData in Room automatically uses a background thread for database calls. You don't have to explicitly specify the Dispatcher.IO. Room does it for you in generated implementation.